### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SteamCMD GUI by Raúl 'Dio Joestar' Jiménez is licensed under a [Creative Commo
 
 Last Changes
 ============
-######Version 3.1.0.2
+###### Version 3.1.0.2
 * Custom Mod now is saved by XML config ~ By Melo88 @ GitHub
 
 Screenshots
@@ -24,7 +24,7 @@ Download
 ============
 Get the last version from GitHub right [here] (https://github.com/DioJoestar/SteamCMD-GUI/releases/latest) or use one of the mirrors from below.
 
-######Mirrors
+###### Mirrors
 * [Gamebanana] (http://steam.gamebanana.com/tools/5560)
 * [Spanish Development Kit (OnlineSDK)] (http://onlinesdk.webege.com/recursos/SteamCMD%20GUI.zip)
 * [Dropbox] (https://dl.dropboxusercontent.com/u/12664902/SteamCMD%20GUI.zip)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
